### PR TITLE
Vendor gz_math6 unconditionally.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,8 @@ project(ignition_math6_vendor)
 find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
-find_package(ignition-math6 6.9.2 QUIET)
 
 ament_vendor(ignition_math6_vendor
-  SATISFIED ${ignition-math6_FOUND}
   VCS_URL https://github.com/ignitionrobotics/ign-math.git
   VCS_VERSION ignition-math6_6.9.2
   PATCHES patches

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
   <depend>ignition_cmake2_vendor</depend>
-  <depend>ignition-math6</depend>
 
   <build_depend>eigen</build_depend>
 


### PR DESCRIPTION
On Ubuntu Noble, there is no usable upstream version of gz-math6 and we are in the process of updating all Gazebo packages to be directly vendorable. In the meantime, switch the current Gazebo vendor packages in ROS 2 core to vendor unconditionally.